### PR TITLE
Bug/score-calculation

### DIFF
--- a/src/Validation/DataObject/Attributes/AbstractAttribute.php
+++ b/src/Validation/DataObject/Attributes/AbstractAttribute.php
@@ -9,6 +9,7 @@ use Pimcore\Model\Element\ElementInterface;
 use ReflectionException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -42,7 +43,7 @@ abstract class AbstractAttribute implements ValidatableInterface, ScorableInterf
      *
      * @var array|ConstraintViolationListInterface[]
      */
-    protected array $violations = [];
+    protected ConstraintViolationList $violations;
     protected AbstractDefinitionInformation $classInformation;
 
     /**

--- a/src/Validation/DataObject/Attributes/AbstractAttribute.php
+++ b/src/Validation/DataObject/Attributes/AbstractAttribute.php
@@ -38,11 +38,6 @@ abstract class AbstractAttribute implements ValidatableInterface, ScorableInterf
     protected array $skippedConstraints;
     protected ?bool $ignoreFallbackLanguage;
 
-    /**
-     * Violations found during validation.
-     *
-     * @var array|ConstraintViolationListInterface[]
-     */
     protected ConstraintViolationList $violations;
     protected AbstractDefinitionInformation $classInformation;
 

--- a/src/Validation/DataObject/Attributes/AbstractAttribute.php
+++ b/src/Validation/DataObject/Attributes/AbstractAttribute.php
@@ -38,6 +38,11 @@ abstract class AbstractAttribute implements ValidatableInterface, ScorableInterf
     protected array $skippedConstraints;
     protected ?bool $ignoreFallbackLanguage;
 
+    /**
+     * Violations found during validation.
+     *
+     * @var ConstraintViolationList
+     */
     protected ConstraintViolationList $violations;
     protected AbstractDefinitionInformation $classInformation;
 


### PR DESCRIPTION
In the  Valantic\DataQualityBundle\Validation\DataObject\Attributes\AbstractAttribute class wich is called from the
showAction() method from ScoreController:87 calls the validate() function ->
 
    protected array $violations = []; , line:45

    public function validate(): void
    {
        try

{             $this->violations = $this->getValidator()->validate($this->value(), $this->getConstraints(), $this->groups);         }
catch (\Throwable $e)

{             $this->eventDispatcher->dispatch(new ConstraintFailureEvent($e, $this->obj->getId(), $this->attribute, $this->violations));         }
    }
 
$this->getValidator()>validate($this>value(), $this->getConstraints(), $this->groups);,
this method returns a object ConstraintViolationList but expects an array,
so when trying to assign the  protected array $violations = []; it will throw this error:
"Cannot assign Symfony\Component\Validator\ConstraintViolationList to property Valantic\DataQualityBundle\Validation\DataObject\Attributes\AbstractAttribute::$violations of type array"

So the fix here is to change the 
    protected array $violations = [];
    to this:   
    protected ConstraintViolationList $violations;